### PR TITLE
Fix for python 3.x and changed to PEP-8 style

### DIFF
--- a/hungarian.py
+++ b/hungarian.py
@@ -197,8 +197,8 @@ class Hungarian:
 
     def __find_matches(self, zero_locations):
         """Returns rows and columns with matches in them."""
-        marked_rows = np.array([])
-        marked_columns = np.array([])
+        marked_rows = np.array([], dtype=int)
+        marked_columns = np.array([], dtype=int)
 
         # Mark rows and columns with matches
         # Iterate over rows
@@ -453,7 +453,6 @@ if __name__ == '__main__':
         [4, 2, 8],
         [4, 3, 7],
         [3, 1, 6]]
-
     hungarian = Hungarian(cost_matrix)
     print('calculating...')
     hungarian.calculate()


### PR DESCRIPTION
First of all, I changed the whole code-style to conform to PEP-8. Obviously I don't want to 'take over' your coding style, so if you don't like that I can obviously revert the style changes. 
Furthermore, I updated everything to work with the latest versions of Python as well as Numpy (furthermore I also tested it with Python 2.7). Additionally I made a minor change, that it now accepts numpy arrays in addition to list of lists and removed the `padMatrix` function to use numpy's `resize` function.

Just let me know if there is anything else you think is necessary.

Also, it would be great to add this to https://pypi.python.org/pypi I have never done that though. But let me know what you think.
